### PR TITLE
Fix for DeploymentStatusReport problem

### DIFF
--- a/AppCenterAssets/AppCenterAssets/DeploymentInstance/MSAssetsDeploymentInstance.m
+++ b/AppCenterAssets/AppCenterAssets/DeploymentInstance/MSAssetsDeploymentInstance.m
@@ -277,12 +277,6 @@ static BOOL isRunningBinaryVersion = NO;
         syncOptions = [[MSAssetsSyncOptions alloc] init];
     if (!syncOptions.deploymentKey)
         syncOptions.deploymentKey = self.deploymentKey;
-    if (!syncOptions.installMode)
-        syncOptions.installMode = MSAssetsInstallModeOnNextRestart;
-    if (!syncOptions.mandatoryInstallMode)
-        syncOptions.mandatoryInstallMode = MSAssetsInstallModeImmediate;
-    if (!syncOptions.checkFrequency)
-        syncOptions.checkFrequency = MSAssetsCheckFrequencyOnAppStart;
 
     NSError *configError = nil;
     MSAssetsConfiguration *config = [self getConfigurationWithError:&configError];
@@ -625,6 +619,16 @@ static BOOL isRunningBinaryVersion = NO;
         } else {
             [[strongSelf restartManager] clearPendingRestarts];
         }
+        
+        if (resolvedInstallMode == MSAssetsInstallModeImmediate) {
+            if ([syncOptions shouldRestart]) {
+                [[strongSelf restartManager] restartAppOnlyIfUpdateIsPending:NO];
+            } else {
+                self.instanceState.didUpdate = YES;
+                [[strongSelf restartManager] clearPendingRestarts];
+            }
+        }
+        
         handler(nil);
     }];
 }

--- a/AppCenterAssets/AppCenterAssets/Internals/Model/MSAssetsSyncOptions.m
+++ b/AppCenterAssets/AppCenterAssets/Internals/Model/MSAssetsSyncOptions.m
@@ -17,6 +17,9 @@ static NSString *const kMSShouldRestart = @"shouldRestart";
 
 - (instancetype)init {
     self = [super init];
+        self.installMode = MSAssetsInstallModeOnNextRestart;
+        self.mandatoryInstallMode = MSAssetsInstallModeImmediate;
+        self.checkFrequency = MSAssetsCheckFrequencyOnAppStart;
     return self;
 }
 

--- a/Puppet/Puppet/MSAssetsViewController.m
+++ b/Puppet/Puppet/MSAssetsViewController.m
@@ -90,6 +90,8 @@
     MSAssetsSyncOptions *syncOptions = [MSAssetsSyncOptions new];
     [syncOptions setDeploymentKey:@kDeploymentKey];
     [syncOptions setUpdateDialog:[MSAssetsUpdateDialog new]];
+    [syncOptions setInstallMode:MSAssetsInstallModeImmediate];
+    [syncOptions setShouldRestart:NO];
     [self.assetsDeployment sync:syncOptions];
 }
 


### PR DESCRIPTION
Fix for issue, when deployment status report is not sent for assets update with no_restart & immediate_update mode.
Calling app should define appropriate sync options in calling application, as default sync mode is "OnNextRestart" :

` [syncOptions setInstallMode:MSAssetsInstallModeImmediate];
 [syncOptions setShouldRestart:NO];`